### PR TITLE
Refresh picker UI in DateTimePickerAdapter.doSelect

### DIFF
--- a/lib/Picker.dart
+++ b/lib/Picker.dart
@@ -1247,12 +1247,11 @@ class DateTimePickerAdapter extends PickerAdapter<DateTime> {
     if (minValue != null &&
         (value.millisecondsSinceEpoch < minValue.millisecondsSinceEpoch)) {
       value = minValue;
-      notifyDataChanged();
     } else if (maxValue != null &&
         value.millisecondsSinceEpoch > maxValue.millisecondsSinceEpoch) {
       value = maxValue;
-      notifyDataChanged();
     }
+    notifyDataChanged();
   }
 
   int _getAPColIndex() {


### PR DESCRIPTION
If new value is within the valid range, still should invoke notifyDataChanged to refresh the picker UI.