### PR TITLE
Add useRootNavigator argument to Picker.showModal()

### DIFF
--- a/lib/Picker.dart
+++ b/lib/Picker.dart
@@ -169,10 +169,13 @@ class Picker {
 
   /// Display modal picker
   Future<T?> showModal<T>(BuildContext context,
-      [ThemeData? themeData, bool isScrollControlled = false]) async {
+      [ThemeData? themeData,
+      bool isScrollControlled = false,
+      bool useRootNavigator = false]) async {
     return await showModalBottomSheet<T>(
         context: context, //state.context,
         isScrollControlled: isScrollControlled,
+        useRootNavigator: useRootNavigator,
         builder: (BuildContext context) {
           return makePicker(themeData, true);
         });


### PR DESCRIPTION
In the case that a picker modal is being displayed from a widget which is in a nested navigation controller (for example, if there is a bottom navigation bar), it's helpful to have a `useRootNavigator` argument on the `Picker.showModal` method.

This way, when a `Picker` is displayed from such a widget, it will be shown at the very bottom of the screen, rather than above the bottom navigation bar.