### PR TITLE
fix #165: add Key parameter to `makePicker`

### DIFF
--- a/lib/Picker.dart
+++ b/lib/Picker.dart
@@ -147,12 +147,12 @@ class Picker {
 
   /// 生成picker控件
   /// Build picker control
-  Widget makePicker([ThemeData? themeData, bool isModal = false]) {
+  Widget makePicker([ThemeData? themeData, bool isModal = false, Key? key]) {
     _maxLevel = adapter.maxLevel;
     adapter.picker = this;
     adapter.initSelects();
     _widget = PickerWidget(
-      key: ValueKey(this),
+      key: key ?? ValueKey(this),
       child:
           _PickerWidget(picker: this, themeData: themeData, isModal: isModal),
       data: this,
@@ -215,7 +215,8 @@ class Picker {
               actions.add(TextButton(
                   style: _getButtonStyle(ButtonTheme.of(context)),
                   onPressed: () async {
-                    if (onConfirmBefore != null && !(await onConfirmBefore!(this, selecteds))) {
+                    if (onConfirmBefore != null &&
+                        !(await onConfirmBefore!(this, selecteds))) {
                       return; // Cancel;
                     }
                     Navigator.pop<List<int>>(context, selecteds);
@@ -1132,7 +1133,12 @@ class DateTimePickerAdapter extends PickerAdapter<DateTime> {
   final int? minuteInterval;
 
   /// Year, month, day suffix
-  final String? yearSuffix, monthSuffix, daySuffix, hourSuffix, minuteSuffix, secondSuffix;
+  final String? yearSuffix,
+      monthSuffix,
+      daySuffix,
+      hourSuffix,
+      minuteSuffix,
+      secondSuffix;
 
   /// use two-digit year, 2019, displayed as 19
   final bool twoDigitYear;
@@ -1215,7 +1221,7 @@ class DateTimePickerAdapter extends PickerAdapter<DateTime> {
     if (!_needUpdatePrev) {
       // check am/pm before hour-ap
       var ap = _columnType.indexWhere((element) => element == 6);
-      if (ap >  _columnType.indexWhere((element) => element == 7)) {
+      if (ap > _columnType.indexWhere((element) => element == 7)) {
         _apBeforeHourAp = true;
         _needUpdatePrev = true;
       }
@@ -1432,7 +1438,8 @@ class DateTimePickerAdapter extends PickerAdapter<DateTime> {
         if (minuteInterval == null || minuteInterval! < 2)
           _text = "${intToStr(index)}${_checkStr(minuteSuffix)}";
         else
-          _text = "${intToStr(index * minuteInterval!)}${_checkStr(minuteSuffix)}";
+          _text =
+              "${intToStr(index * minuteInterval!)}${_checkStr(minuteSuffix)}";
         break;
       case 6:
         List? _ampm = strAMPM ?? PickerLocalizations.of(context).ampm;


### PR DESCRIPTION
This will fix #165.

I added `key` parameter to `makePicker` method.  If I pass consistent key to  makePicker, the picker's dragging behavior is not interrupted (this is my expected behavior.)

If I call `makePicker` on `build` method, every build use different key ('ValueKey(this)') for `PickerWidget` and this interrupt dragging (scrolling). With this PR, we can assign key for `PickerWidget` explicitly or we can omit key for using conventional key ('ValueKey(this)').

👇 is sample code to use this parameter.

```dart
final picker = Picker(...);
return picker.makePicker(Theme.of(context), false, ValueKey('MyKey'));
```

If #165 is not correct usage, please close this PR 😢  Thank you ❤️ 

