### PR TITLE
修复只设置年月时，选中颜色错乱

### DIFF
--- a/lib/picker.dart
+++ b/lib/picker.dart
@@ -1284,8 +1284,10 @@ class DateTimePickerAdapter extends PickerAdapter<DateTime> {
       _columnType = columnType[type];
     var month = _columnType.indexWhere((element) => element == 1);
     var day = _columnType.indexWhere((element) => element == 2);
-    _needUpdatePrev =
-        day < month || day < _columnType.indexWhere((element) => element == 0);
+    if (month != -1 && day != -1) {
+      _needUpdatePrev = day < month ||
+          day < _columnType.indexWhere((element) => element == 0);
+    }
     if (!_needUpdatePrev) {
       // check am/pm before hour-ap
       var ap = _columnType.indexWhere((element) => element == 6);


### PR DESCRIPTION
如果只设置年月时day=-1，_needUpdatePrev=true。这就导致了每次滚动年时，选中颜色不刷新。