### PR TITLE
chore: deprecation new API from  headline6 to titleLarge [https://doc…

### DIFF
--- a/lib/picker.dart
+++ b/lib/picker.dart
@@ -479,7 +479,7 @@ class PickerWidgetState<T> extends State<_PickerWidget> {
       child: picker.title == null
           ? SizedBox()
           : DefaultTextStyle(
-              style: (theme!.textTheme.headline6 ?? theme!.textTheme.titleLarge)
+              style: (theme!.textTheme.titleLarge ?? theme!.textTheme.titleLarge)
                       ?.copyWith(
                     fontSize: Picker.DefaultTextSize,
                   ) ??
@@ -736,7 +736,7 @@ abstract class PickerAdapter<T> {
                         : Colors.black87,
                     fontFamily: theme == null
                         ? ""
-                        : theme.textTheme.headline6?.fontFamily,
+                        : theme.textTheme.titleLarge?.fontFamily,
                     fontSize: Picker.DefaultTextSize),
             child: child != null
                 ? (isSel && picker!.selectedIconTheme != null
@@ -781,7 +781,7 @@ abstract class PickerAdapter<T> {
                     fontSize: _txtSize,
                     fontFamily: theme == null
                         ? ""
-                        : theme.textTheme.headline6?.fontFamily),
+                        : theme.textTheme.titleLarge?.fontFamily),
             child: Wrap(
               children: items,
             )));


### PR DESCRIPTION
chore: deprecation new API from  headline6 to titleLarge [here..](https://docs.flutter.dev/release/breaking-changes/3-19-deprecations)
- update bottomAppBarColor was fixed at Rev-Number 112e877eb0053da022ae7a90a5e6865a51fbfdee from https://github.com/yangyxd/flutter_picker/commit/112e877eb0053da022ae7a90a5e6865a51fbfdee