### PR TITLE
removed broken getWidget function

### DIFF
--- a/lib/picker.dart
+++ b/lib/picker.dart
@@ -217,11 +217,7 @@ class Picker {
           return builder == null ? picker : builder(context, picker);
         });
   }
-    
-  /// get widget
-  Widget getWidget(BuildContext context) {
-    return builder == null ? picker : builder(context, picker);
-  }
+
 
   /// show dialog picker
   Future<List<int>?> showDialog(BuildContext context,


### PR DESCRIPTION
This pull request includes a small change to the `Picker` class in the `lib/picker.dart` file. The change involves the removal of the `getWidget` method, which was previously used to return a widget based on the presence of a builder function. 

However, this function breaks the project and does not compile.